### PR TITLE
Update cursive-core to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/cursive-async-view"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cursive_core = "0.3"
+cursive_core = "0.4"
 log = "0.4"
 interpolation = "0.2"
 crossbeam = "0.8"
@@ -23,4 +23,4 @@ lazy_static = "1.4"
 doc-comment = "0.3"
 
 [dev-dependencies]
-cursive = "0.17.0"
+cursive = "0.21.0"

--- a/src/infinite.rs
+++ b/src/infinite.rs
@@ -324,8 +324,9 @@ pub enum AsyncState<V: View> {
 pub struct AsyncView<T: View> {
     view: AsyncState<T>,
     loading: TextView,
-    animation_fn: Box<dyn Fn(usize, usize, usize) -> AnimationFrame + 'static>,
-    error_fn: Box<dyn Fn(&str, usize, usize, usize, usize) -> AnimationFrame + 'static>,
+    animation_fn: Box<dyn Fn(usize, usize, usize) -> AnimationFrame + Send + Sync + 'static>,
+    error_fn:
+        Box<dyn Fn(&str, usize, usize, usize, usize) -> AnimationFrame + Send + Sync + 'static>,
     width: Option<usize>,
     height: Option<usize>,
     pos: usize,
@@ -506,7 +507,7 @@ impl<T: View> AsyncView<T> {
         // 'static, meaning it owns all values and does not reference anything
         // outside of its scope. In practice this means all animation_fn must be
         // `move |width| {...}` or fn's.
-        F: Fn(usize, usize, usize) -> AnimationFrame + 'static,
+        F: Fn(usize, usize, usize) -> AnimationFrame + Send + Sync + 'static,
     {
         self.set_animation_fn(animation_fn);
         self
@@ -523,7 +524,7 @@ impl<T: View> AsyncView<T> {
         // 'static, meaning it owns all values and does not reference anything
         // outside of its scope. In practice this means all animation_fn must be
         // `move |width| {...}` or fn's.
-        F: Fn(&str, usize, usize, usize, usize) -> AnimationFrame + 'static,
+        F: Fn(&str, usize, usize, usize, usize) -> AnimationFrame + Send + Sync + 'static,
     {
         self.set_error_fn(error_fn);
         self
@@ -547,7 +548,7 @@ impl<T: View> AsyncView<T> {
     /// the previous loading animation has already started.
     pub fn set_animation_fn<F>(&mut self, animation_fn: F)
     where
-        F: Fn(usize, usize, usize) -> AnimationFrame + 'static,
+        F: Fn(usize, usize, usize) -> AnimationFrame + Send + Sync + 'static,
     {
         self.animation_fn = Box::new(animation_fn);
     }
@@ -560,7 +561,7 @@ impl<T: View> AsyncView<T> {
     /// the previous error animation has already started.
     pub fn set_error_fn<F>(&mut self, error_fn: F)
     where
-        F: Fn(&str, usize, usize, usize, usize) -> AnimationFrame + 'static,
+        F: Fn(&str, usize, usize, usize, usize) -> AnimationFrame + Send + Sync + 'static,
     {
         self.error_fn = Box::new(error_fn);
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -260,9 +260,15 @@ pub fn default_progress_error(
 pub struct AsyncProgressView<T: View> {
     view: AsyncProgressState<T>,
     loading: TextView,
-    progress_fn: Box<dyn Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static>,
-    error_fn:
-        Box<dyn Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static>,
+    progress_fn: Box<
+        dyn Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + Send + Sync + 'static,
+    >,
+    error_fn: Box<
+        dyn Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame
+            + Send
+            + Sync
+            + 'static,
+    >,
     width: Option<usize>,
     height: Option<usize>,
     view_rx: Receiver<AsyncProgressState<T>>,
@@ -383,7 +389,7 @@ impl<T: View> AsyncProgressView<T> {
     /// example on how to create a custom progress function.
     pub fn with_progress_fn<F>(mut self, progress_fn: F) -> Self
     where
-        F: Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static,
+        F: Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + Send + Sync + 'static,
     {
         self.set_progress_fn(progress_fn);
         self
@@ -391,7 +397,10 @@ impl<T: View> AsyncProgressView<T> {
 
     pub fn with_error_fn<F>(mut self, error_fn: F) -> Self
     where
-        F: Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static,
+        F: Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame
+            + Send
+            + Sync
+            + 'static,
     {
         self.set_error_fn(error_fn);
         self
@@ -415,7 +424,7 @@ impl<T: View> AsyncProgressView<T> {
     /// the previous progress bar has already be drawn.
     pub fn set_progress_fn<F>(&mut self, progress_fn: F)
     where
-        F: Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static,
+        F: Fn(usize, usize, f32, usize, usize) -> AnimationProgressFrame + Send + Sync + 'static,
     {
         self.progress_fn = Box::new(progress_fn);
     }
@@ -428,7 +437,10 @@ impl<T: View> AsyncProgressView<T> {
     /// the previous progress bar has already be drawn.
     pub fn set_error_fn<F>(&mut self, error_fn: F)
     where
-        F: Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame + 'static,
+        F: Fn(String, usize, usize, f32, usize, usize) -> AnimationProgressFrame
+            + Send
+            + Sync
+            + 'static,
     {
         self.error_fn = Box::new(error_fn);
     }


### PR DESCRIPTION
`View` now require `Sync + Send`, so forward these requirements to
stored callbacks.
